### PR TITLE
Adding custom Document page with CDN links for rendering SVGs of icons

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            rel='stylesheet'
+            href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/eos-icons.css'
+          />
+          <link
+            rel='stylesheet'
+            href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css'
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument


### PR DESCRIPTION
It was not possible to render the icon SVGs from the eos-icons npm package for some reason. I have added the CDN links for both normal and outlined icons in the custom Document structure to render the SVGs from there while iterating over the icons list provided from eos-icons npm package.